### PR TITLE
If the text looks like a link in markdown, then we parse it as a link

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro-apps/gitlab",
   "title": "GitLab",
   "description": "View your GitLab issues from Deskpro and link them to tickets you are working on.",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/utils/mdToHtml.ts
+++ b/src/utils/mdToHtml.ts
@@ -3,6 +3,7 @@ import showdown from "showdown";
 const converter = new showdown.Converter({
     tables: true,
     strikethrough: true,
+    simplifiedAutoLink: true,
     openLinksInNewWindow: true,
 });
 


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/97025/gitlab-links-aren-t-clickable