### PR TITLE
Getting all members also who are in groups

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "@deskpro-apps/gitlab",
   "title": "GitLab",
   "description": "View your GitLab issues from Deskpro and link them to tickets you are working on.",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "scope": "agent",
   "isSingleInstall": false,
   "hasDevMode": true,

--- a/src/services/gitlab/getProjectMembersService.ts
+++ b/src/services/gitlab/getProjectMembersService.ts
@@ -7,7 +7,7 @@ const getProjectMembersService = (
     projectId: Project["id"],
 ) => {
     return baseRequest<Member[]>(client, {
-        url: `/projects/${projectId}/members`,
+        url: `/projects/${projectId}/members/all`,
     });
 };
 


### PR DESCRIPTION
Story https://app.shortcut.com/deskpro/story/101686/gitlab-can-t-see-assignees-in-groups