### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -102,7 +102,15 @@
       {
         "url": "__gitlab_instance_url__/.*",
         "methods": ["GET", "POST", "PUT"],
-        "timeout": 10
+        "timeout": 10,
+        "settingsInjection": {
+          "app_id": {
+            "querystring": ["client_id"]
+          },
+          "client_secret": {
+            "querystring": ["client_secret"]
+          }
+        }
       }
     ]
   }

--- a/src/services/gitlab/constants.ts
+++ b/src/services/gitlab/constants.ts
@@ -4,7 +4,7 @@ export const placeholders = {
     gitlab_instance_url: "__gitlab_instance_url__",
     TOKEN: "[user[oauth2/token]]",
     TOKEN_PATH: "oauth2/token",
-};
+} as const;
 
 export const BASE_URL = "__gitlab_instance_url__";
 


### PR DESCRIPTION
This pull request introduces improvements to how configuration settings are injected into requests and enforces stricter typing for GitLab service constants. The most important changes are grouped below:

Configuration and Settings Injection:

* Added a `settingsInjection` object to the GitLab API route in `manifest.json`, enabling automatic injection of `app_id` and `client_secret` from settings into the querystring parameters `client_id` and `client_secret`.

Type Safety and Constants:

* Updated the `placeholders` export in `src/services/gitlab/constants.ts` to use `as const`, ensuring stricter type safety for these constants throughout the codebase.

## Summary by Sourcery

Add settingsInjection config to the GitLab API proxy in manifest.json for secure credential injections and enforce stricter typing on GitLab service constants.

New Features:
- Introduce settingsInjection in manifest.json to map app_id and client_secret into querystring parameters for GitLab API routes

Enhancements:
- Export placeholders in GitLab constants as const to strengthen type safety